### PR TITLE
fix: Change number-leading-zero to always

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
     'string-quotes': 'single',
     'font-family-name-quotes': 'always-where-required',
     'value-list-comma-space-after': 'always',
-    'number-leading-zero': 'never',
+    'number-leading-zero': 'always',
     'color-hex-length': 'short',
     'color-hex-case': 'lower',
     'no-descending-specificity': null,


### PR DESCRIPTION
## What

stylelint(number-leading-zero: never) and prettier conflict.
I want to change the prettier settings but prettier has no leading 0 option ...

I changed number-leading-zero to always.