### PR TITLE
fix: Remove deprecated processor

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,15 +6,15 @@ module.exports = {
   ],
   syntax: 'scss',
   rules: {
-    'value-keyword-case': ['lower', {
-      ignoreKeywords: 'dummyValue'
-    }],
+    'value-keyword-case': null,
     'property-case': 'lower',
     'unit-case': 'lower',
+    'function-name-case': null,
     'declaration-colon-space-before': 'never',
     'declaration-colon-space-after': 'always-single-line',
     'declaration-block-trailing-semicolon': 'always',
     'declaration-block-semicolon-newline-after': 'always',
+    'declaration-empty-line-before': null,
     'block-closing-brace-empty-line-before': 'never',
     'block-closing-brace-newline-after': 'always',
     'block-opening-brace-space-before': 'always',

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 module.exports = {
-  processors: ['stylelint-processor-styled-components'],
   extends: [
     'stylelint-config-standard',
     'stylelint-config-styled-components',

--- a/package.json
+++ b/package.json
@@ -37,14 +37,12 @@
     "stylelint": "^13.6.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-standard": "^20.0.0",
-    "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.10.0"
+    "stylelint-config-styled-components": "^0.1.1"
   },
   "peerDependencies": {
     "stylelint": "^13.2.1",
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-config-standard": "^20.0.0",
-    "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.10.0"
+    "stylelint-config-styled-components": "^0.1.1"
   }
 }

--- a/test/__snapshots__/run.test.js.snap
+++ b/test/__snapshots__/run.test.js.snap
@@ -4,11 +4,6 @@ exports[`fixtures should match the snapshot 1`] = `
 Object {
   "index.tsx": Array [
     Object {
-      "rule": "block-closing-brace-empty-line-before",
-      "severity": "error",
-      "text": "Unexpected empty line before closing backtick (block-closing-brace-empty-line-before)",
-    },
-    Object {
       "rule": "block-no-empty",
       "severity": "error",
       "text": "Unexpected empty block (block-no-empty)",

--- a/test/__snapshots__/run.test.js.snap
+++ b/test/__snapshots__/run.test.js.snap
@@ -44,11 +44,6 @@ Object {
       "text": "Unexpected whitespace before \\":\\" (declaration-colon-space-before)",
     },
     Object {
-      "rule": "declaration-empty-line-before",
-      "severity": "error",
-      "text": "Expected empty line before declaration (declaration-empty-line-before)",
-    },
-    Object {
       "rule": "font-family-name-quotes",
       "severity": "error",
       "text": "Unexpected quotes around \\"Arial\\" (font-family-name-quotes)",

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,7 +300,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.3", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
   version "7.9.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.4.tgz#68a35e6b0319bbc014465be43828300113f2f2e8"
   integrity sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
@@ -426,7 +426,7 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
   integrity sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==
@@ -5351,16 +5351,6 @@ stylelint-config-styled-components@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/stylelint-config-styled-components/-/stylelint-config-styled-components-0.1.1.tgz#b408388d7c687833ab4be4c4e6522d97d2827ede"
   integrity sha512-z5Xz/9GmvxO6e/DLzBMwkB85zHxEEjN6K7Cj80Bi+o/9vR9eS3GX3E9VuMnX9WLFYulqbqLtTapGGY28JBiy9Q==
-
-stylelint-processor-styled-components@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/stylelint-processor-styled-components/-/stylelint-processor-styled-components-1.10.0.tgz#8082fc68779476aac411d3afffac0bc833d77a29"
-  integrity sha512-g4HpN9rm0JD0LoHuIOcd/FIjTZCJ0ErQ+dC3VTxp+dSvnkV+MklKCCmCQEdz5K5WxF4vPuzfVgdbSDuPYGZhoA==
-  dependencies:
-    "@babel/parser" "^7.8.3"
-    "@babel/traverse" "^7.8.3"
-    micromatch "^4.0.2"
-    postcss "^7.0.26"
 
 stylelint@^13.6.1:
   version "13.6.1"


### PR DESCRIPTION
`stylelint-processor-styled-components`はメンテされておらず、parserが古いことで新しいsyntaxを利用できない問題があります。
`stylelint`単体でもCSS-in-JSをある程度解釈できるようになっているため、まだ不具合のあるルールについては緩和した上で`stylelint-processor-styled-components`を外します。