### PR TITLE
docs: remove unnecessary package from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is intended to use for a project with styled-components.
 ## Install
 
 ```sh
-yarn add --dev stylelint stylelint-config-prettier stylelint-config-standard stylelint-config-styled-components stylelint-processor-styled-components // install peerDependencies
+yarn add --dev stylelint stylelint-config-prettier stylelint-config-standard stylelint-config-styled-components // install peerDependencies
 yarn add --dev stylelint-config-smarthr
 ```
 


### PR DESCRIPTION
`stylelint-processor-styled-components` is now unnecessary so I remove it from README.