### PR TITLE
feat: word-break: break-all, word-break: brake-word の利用を禁止する

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,12 +23,13 @@ module.exports = {
         'word-break': ['break-all', 'break-word'],
       },
       {
-        'message': `"word-break: break-all;" "word-break: break-word" 以下の理由で非推奨です
- - "break-all" は英単語などが不自然に改行される可能性があるため非推奨です。
- - "break-word" は仕様として非推奨になっています
+        'message': `"word-break: break-all;" "word-break: break-word" は非推奨なstyleです
+ - "break-all" は英単語などが不自然に改行され、非常に読みづらくなるため利用しないでください
+ - "break-word" は仕様として非推奨です
+   - https://developer.mozilla.org/ja/docs/Web/CSS/word-break#break-word
  - いずれの場合も以下で対応可能です
-   - "overflow-wrap: anywhere;" を利用することでなるべく単語を改行せず、かつどうしても横幅に収まらない場合のみ単語内で改行されるようになります。
-   - "overflow-wrap: anywhere;" だけではうまく改行指定出来ない場合、"word-break: normal;" も同時に指定すると改善する場合があります。`
+   - "overflow-wrap: anywhere;" を利用することでなるべく単語を改行せず、かつどうしても横幅に収まらない場合のみ単語内で改行されるようになります
+   - "overflow-wrap: anywhere;" だけではうまく改行指定出来ない場合、"word-break: normal;" も同時に指定すると改善する場合があります`
       }
     ]
   }

--- a/index.js
+++ b/index.js
@@ -17,6 +17,19 @@ module.exports = {
     'selector-class-pattern': null,
     'value-no-vendor-prefix': true,
     'property-no-vendor-prefix': true,
-    'no-empty-source': null
+    'no-empty-source': null,
+    'declaration-property-value-disallowed-list': [
+      {
+        'word-break': ['break-all', 'break-word'],
+      },
+      {
+        'message': `"word-break: break-all;" "word-break: break-word" 以下の理由で非推奨です
+ - "break-all" は英単語などが不自然に改行される可能性があるため非推奨です。
+ - "break-word" は仕様として非推奨になっています
+ - いずれの場合も以下で対応可能です
+   - "overflow-wrap: anywhere;" を利用することでなるべく単語を改行せず、かつどうしても横幅に収まらない場合のみ単語内で改行されるようになります。
+   - "overflow-wrap: anywhere;" だけではうまく改行指定出来ない場合、"word-break: normal;" も同時に指定すると改善する場合があります。`
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "standard-version": "^9.3.2",
     "styled-components": "^5.3.11",
     "stylelint": "^16.10.0",
+    "stylelint-config-sass-guidelines": "^12.1.0",
     "stylelint-config-standard": "^36.0.1",
     "vitest": "^2.0.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,20 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@stylistic/stylelint-plugin@^3.0.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@stylistic/stylelint-plugin/-/stylelint-plugin-3.1.1.tgz#2503ef353d50bbdf495db4bb1b87ca7f639f16d6"
+  integrity sha512-XagAHHIa528EvyGybv8EEYGK5zrVW74cHpsjhtovVATbhDRuJYfE+X4HCaAieW9lCkwbX6L+X0I4CiUG3w/hFw==
+  dependencies:
+    "@csstools/css-parser-algorithms" "^3.0.1"
+    "@csstools/css-tokenizer" "^3.0.1"
+    "@csstools/media-query-list-parser" "^3.0.1"
+    is-plain-object "^5.0.0"
+    postcss-selector-parser "^6.1.2"
+    postcss-value-parser "^4.2.0"
+    style-search "^0.1.0"
+    stylelint "^16.8.2"
+
 "@types/babel__core@^7.1.14":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -3315,6 +3329,11 @@ mdn-data@2.10.0:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.10.0.tgz#701da407f8fbc7a42aa0ba0c149ec897daef8986"
   integrity sha512-qq7C3EtK3yJXMwz1zAab65pjl+UhohqMOctTgcqjLOWABqmwj+me02LSsCuEUxnst9X1lCBpoE0WArGKgdGDzw==
 
+mdn-data@^2.11.1:
+  version "2.12.2"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.12.2.tgz#9ae6c41a9e65adf61318b32bff7b64fbfb13f8cf"
+  integrity sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==
+
 meow@^13.2.0:
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-13.2.0.tgz#6b7d63f913f984063b3cc261b6e8800c4cd3474f"
@@ -3776,6 +3795,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+postcss-media-query-parser@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+  integrity sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==
+
 postcss-resolve-nested-selector@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz#3d84dec809f34de020372c41b039956966896686"
@@ -3785,6 +3809,11 @@ postcss-safe-parser@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz#36e4f7e608111a0ca940fd9712ce034718c40ec0"
   integrity sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==
+
+postcss-scss@^4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.9.tgz#a03c773cd4c9623cb04ce142a52afcec74806685"
+  integrity sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==
 
 postcss-selector-parser@^6.1.2:
   version "6.1.2"
@@ -4371,6 +4400,11 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+style-search@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+  integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
+
 styled-components@^5.3.11:
   version "5.3.11"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.11.tgz#9fda7bf1108e39bf3f3e612fcc18170dedcd57a8"
@@ -4392,6 +4426,15 @@ stylelint-config-recommended@^14.0.1:
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz#d25e86409aaf79ee6c6085c2c14b33c7e23c90c6"
   integrity sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==
 
+stylelint-config-sass-guidelines@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-12.1.0.tgz#6c7f108f2293684b9a6db5b290d293475d9fde22"
+  integrity sha512-NTxEtVT6uNSqRvq+A3ScyKhjUrY/Z845TnpWEwnMgIPZ/+/Waa4+51r6OPuQRMu4XZS3D8DK1UaT4TWFBvuuAw==
+  dependencies:
+    "@stylistic/stylelint-plugin" "^3.0.1"
+    postcss-scss "^4.0.9"
+    stylelint-scss "^6.2.1"
+
 stylelint-config-standard@^36.0.1:
   version "36.0.1"
   resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz#727cbb2a1ef3e210f5ce8329cde531129f156609"
@@ -4399,7 +4442,21 @@ stylelint-config-standard@^36.0.1:
   dependencies:
     stylelint-config-recommended "^14.0.1"
 
-stylelint@^16.10.0:
+stylelint-scss@^6.2.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-6.8.1.tgz#b6554d93f2ea0bf37ffdcae571bbfaa35d79ba8a"
+  integrity sha512-al+5eRb72bKrFyVAY+CLWKUMX+k+wsDCgyooSfhISJA2exqnJq1PX1iIIpdrvhu3GtJgNJZl9/BIW6EVSMCxdg==
+  dependencies:
+    css-tree "^3.0.0"
+    is-plain-object "^5.0.0"
+    known-css-properties "^0.34.0"
+    mdn-data "^2.11.1"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.6"
+    postcss-selector-parser "^6.1.2"
+    postcss-value-parser "^4.2.0"
+
+stylelint@^16.10.0, stylelint@^16.8.2:
   version "16.10.0"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-16.10.0.tgz#452b42a5d82f2ad910954eb2ba2b3a2ec583cd75"
   integrity sha512-z/8X2rZ52dt2c0stVwI9QL2AFJhLhbPkyfpDFcizs200V/g7v+UYY6SNcB9hKOLcDDX/yGLDsY/pX08sLkz9xQ==


### PR DESCRIPTION
- 英語などの言語でbreak-allされると単語途中で改行されてしまい読みづらくなるので利用を禁止したい
- 基本的にbreak-allが必要になるような長い単語は入力される可能性は低い
- 必要な場合でも `overflow-wrap: anywhere` を指定することでなるべく単語を保ちつつ、必要な場合のみ改行するようになるため、そちらの利用を促したい
- `word-break: break-word` でもいいが、非推奨のため、overflow-wrapの利用を推奨する